### PR TITLE
Use mmap(2) instead of write(2) to copy to the memfd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 
 # Compiler flags
 CFLAGS := -Wall -Wextra -O2 -std=c99
-TARGET_CFLAGS := -Wall -Wextra -O2 -std=c99 -static
+TARGET_CFLAGS := -Wall -Wextra -O2 -std=c99 -static -DCOPY_WITH_MMAP
 LDFLAGS := -static
 
 # OpenSSL flags - prefer shared libraries to avoid static linking warnings
@@ -54,7 +54,7 @@ $(PACKER_BIN): $(PACKER_SOURCES)
 
 # Build loader
 $(LOADER_BIN): $(LOADER_SOURCES)
-	$(TARGET_CC) $(TARGET_CFLAGS) $(STEALTH_FLAGS) $(OPENSSL_CFLAGS) $(INCLUDES) -o $@ $^ $(OPENSSL_LDFLAGS) 2>/dev/null || $(TARGET_CC) $(TARGET_CFLAGS) $(STEALTH_FLAGS) $(OPENSSL_CFLAGS) $(INCLUDES) -o $@ $^ $(OPENSSL_LDFLAGS)
+	$(TARGET_CC) $(TARGET_CFLAGS) $(STEALTH_FLAGS) $(OPENSSL_CFLAGS) $(INCLUDES) -o $@ $^ $(OPENSSL_LDFLAGS) 2>/dev/null || $(TARGET_CC) $(TARGET_CFLAGS) $(STEALTH_FLAGS) $(OPENSSL_CFLAGS) $(INCLUDES) -o $@ $^ $(OPENSSL_LDFLAGS) -lzstd -lz
 
 # Build stub generator 
 $(STUBGEN_BIN): $(STUBGEN_SOURCES)

--- a/include/common.h
+++ b/include/common.h
@@ -46,6 +46,7 @@ typedef struct {
 #define __NR_getpid 172
 #define __NR_getppid 173
 #define __NR_prctl 167
+#define __NR_msync 227
 
 
 static inline long syscall1(long number, long arg1) {

--- a/loader/memexec.c
+++ b/loader/memexec.c
@@ -37,11 +37,35 @@ int execute_from_memory(const uint8_t* elf_data, size_t elf_size, char* const ar
         return -1;
     }
 
+#ifdef COPY_WITH_MMAP
+    // Map file into memory and copy the long way
+    uint8_t *map = (uint8_t *)syscall6(__NR_mmap, (long)NULL, elf_size, PROT_WRITE, MAP_SHARED, memfd, 0);
+    size_t i;
+    if (map == MAP_FAILED) {
+        close(memfd);
+        return -1;
+    }
+    for (i = 0; i < elf_size; ++i) {
+        /* This could be quite a bit faster at the cost of a library call. */
+        map[i] = elf_data[i];
+    }
+#ifdef _POSIX_MAPPED_FILES
+    if (syscall3(__NR_msync, (long)map, elf_size, MS_SYNC) == -1) {
+        close(memfd);
+        return -1;
+    }
+#endif /* #ifdef _POSIX_MAPPED_FILES */
+    if (syscall2(__NR_munmap, (long)map, elf_size) == -1) {
+        close(memfd);
+        return -1;
+    }
+#else /* Not copying with mmap(2). */
     // Write ELF data using direct syscall
     if (syscall3(__NR_write, memfd, (long)elf_data, elf_size) != (long)elf_size) {
         close(memfd);
         return -1;
     }
+#endif /* #ifdef COPY_WITH_MMAP */
 
     char memfd_path[256];
     snprintf(memfd_path, sizeof(memfd_path), "/proc/self/fd/%d", memfd);


### PR DESCRIPTION
Creating the possibility to write in the memory directly with mmap instead of write